### PR TITLE
detect both arm64 and aarch64 as ARM64 architectures during uname checks

### DIFF
--- a/buildDBImage.sh
+++ b/buildDBImage.sh
@@ -155,8 +155,8 @@ processManifest() {
   then
        # Get the correct architecture.
        case "$(uname -m)" in
-            arm64) arch="arm64" ;;   # Match ARM64
-            *)     arch="x86|x64|amd64" ;; # Regexp match for x86 and x64 because non-ARM files are identified by both x86 and x64 :(
+            arm64|aarch64) arch="arm64" ;;   # Match arm64 or aarch64 for ARM64 files
+            *)             arch="x86|x64|amd64" ;; # Regexp match for x86 and x64 because non-ARM files are identified by both x86 and x64 :(
        esac
        grep -i -E "$arch" ./config/manifest | grep -ve "^#" | awk '{print $1,$2,$3,$4,$5}' | while IFS=" " read -r checksum filename filetype version extra
           do

--- a/manageOracle.sh
+++ b/manageOracle.sh
@@ -305,8 +305,8 @@ downloadPatch() {
 
 process_manifest() {
   case "$(uname -m)" in
-       arm64) arch="grep ARM64"    ;;
-       *)     arch="grep -v ARM64" ;;
+       arm64|aarch64) arch="grep ARM64"    ;;
+       *)             arch="grep -v ARM64" ;;
   esac
   
   case $1 in


### PR DESCRIPTION
When working with the current project defaults on an Apple silicon Macbook running Sonoma, the build fails with

``` 
> [db 6/6] RUN  chmod ug+x /opt/scripts/manageOracle.sh &&      /opt/scripts/manageOracle.sh -O:
1.594 0
1.614 unzip:  cannot find or open /opt/install/LINUX.X64_193000_db_home.zip, /opt/install/LINUX.X64_193000_db_home.zip.zip or /opt/install/LINUX.X64_193000_db_home.zip.ZIP.
1.616 ERROR: The installation file (LINUX.X64_193000_db_home.zip) was not found.
1.616 Exiting...
1.632 -bash: /u01/app/oracle/product/19.19/dbhome_1/runInstaller: No such file or directory
```

The architecture of the Oracle Linux 8 image is not detected as `uname -m` returns the synonymous value `aarch64` instead of `arm64`. This change allows for either of the 2 values to indicate an ARM64 architecture.